### PR TITLE
feat: default to colours only if output is a TTY

### DIFF
--- a/hexd.1
+++ b/hexd.1
@@ -7,6 +7,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl p
+.Op Fl P
 .Op Fl g Ar groupsize
 .Op Fl r Ar range
 .Op Fl w Ar width
@@ -30,6 +31,8 @@ The ranges an octet is classified into are
 and
 .Em all
 .Li ( 0xFF ) .
+.Pp
+By default, colours are used if output is a terminal, and omitted if not.
 .Sh OPTIONS
 If no
 .Ar file
@@ -38,6 +41,8 @@ listed below.
 .Bl -tag -width Ds
 .It Fl p
 Plain: disable colours/formatting.
+.It Fl P
+Pretty: enable colours/formatting.
 .It Fl g Ar groupsize
 Number of octets per group, set to
 .Li 8

--- a/hexd.c
+++ b/hexd.c
@@ -145,16 +145,20 @@ struct offset_range parse_range(const char *str) {
 }
 
 int main(int argc, char *argv[]) {
+  // Default to colourful output if output is a TTY
+  option_use_formatting = isatty(1);
+
   // Parse options
   int opt;
-  while (opt = getopt(argc, argv, "g:pr:w:"), opt != -1) {
+  while (opt = getopt(argc, argv, "g:pPr:w:"), opt != -1) {
     switch (opt) {
       case 'g': option_groupsize = atol(optarg); break;
       case 'p': option_use_formatting = false; break;
+      case 'P': option_use_formatting = true; break;
       case 'r': option_range = parse_range(optarg); break;
       case 'w': option_columns = atol(optarg); break;
       default:
-        fprintf(stderr, "usage: hexd [-p] [-g groupsize] [-r range] [-w width]\n");
+        fprintf(stderr, "usage: hexd [-p] [-P] [-g groupsize] [-r range] [-w width]\n");
         return 1;
     }
   }


### PR DESCRIPTION
This is convenient for machine processing of the `hexd` output.

Adds the flag -P ("pretty") to force colours on, complementing -p ("plain"). Resolves #2.